### PR TITLE
Added support for coffeescript, doesn't wrap plain js files (not modules) on 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # browserify-rails
 
+This library adds CommonJS module support to Sprockets (via Browserify).
+
+It let's you mix and match  `//= require` directives and `require()` calls for including plain javascript files as well as modules.
+
 1. Manage JS modules with `npm`
 2. Serve assets with Sprockets
 3. Require modules with `require()` (without separate `//= require` directives)
@@ -40,6 +44,22 @@ module.exports = function (n) { return n * 11 }
 // application.js
 var foo = require('./foo');
 console.log(foo(12));
+```
+
+## Coffeescript
+If you want to use coffeescript files, add coffeeify as a dependency on `package.json`:
+```js
+{
+  "name": "something",
+  "devDependencies" : {
+    "browserify": "2.13.x"
+    "coffeeify": "0.6.x"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">= 0.6"
+  }
+}
 ```
 
 ## Contributing

--- a/lib/browserify-rails/directive_processor.rb
+++ b/lib/browserify-rails/directive_processor.rb
@@ -14,7 +14,7 @@ module BrowserifyRails
 
       raise ArgumentError, "#{browserify_cmd} could not be found. Please run npm install." unless File.exist?(browserify_cmd)
 
-      stdin, stdout, stderr = Open3.popen3("#{browserify_cmd} #{pathname}")
+      stdin, stdout, stderr = Open3.popen3("#{browserify_cmd} -t coffeeify --extension='.coffee' #{pathname}")
       begin
         result = stdout.read
         result_error = stderr.read.strip

--- a/lib/browserify-rails/directive_processor.rb
+++ b/lib/browserify-rails/directive_processor.rb
@@ -3,6 +3,7 @@ require 'open3'
 module BrowserifyRails
   class DirectiveProcessor < Sprockets::DirectiveProcessor
     BROWSERIFY_CMD = './node_modules/.bin/browserify'.freeze
+    COFFEEIFY_PATH = './node_modules/coffeeify'.freeze
 
     class BrowserifyError < ArgumentError
     end
@@ -10,24 +11,35 @@ module BrowserifyRails
     def evaluate(context, locals, &block)
       super
 
-      browserify_cmd = File.join(context.environment.root, BROWSERIFY_CMD)
+      if commonjs_module?(data)
+        browserify_cmd = File.join(context.environment.root, BROWSERIFY_CMD)
 
-      raise ArgumentError, "#{browserify_cmd} could not be found. Please run npm install." unless File.exist?(browserify_cmd)
+        raise ArgumentError, "#{browserify_cmd} could not be found. Please run npm install." unless File.exist?(browserify_cmd)
 
-      stdin, stdout, stderr = Open3.popen3("#{browserify_cmd} -t coffeeify --extension='.coffee' #{pathname}")
-      begin
-        result = stdout.read
-        result_error = stderr.read.strip
-        if result_error.empty?
-          result
-        else
-          raise BrowserifyError, result_error
+        params = "-d"
+        params += " -t coffeeify --extension='.coffee'" if File.directory?(COFFEEIFY_PATH)
+
+        stdin, stdout, stderr = Open3.popen3("#{browserify_cmd} #{params} #{pathname}")
+        begin
+          result = stdout.read
+          result_error = stderr.read.strip
+          if result_error.empty?
+            result
+          else
+            raise BrowserifyError, result_error
+          end
+        ensure
+          stdin.close
+          stdout.close
+          stderr.close
         end
-      ensure
-        stdin.close
-        stdout.close
-        stderr.close
+      else
+        data
       end
+    end
+
+    def commonjs_module?(data)
+      data.to_s.include?('module.exports') || data.to_s.include?('require')
     end
   end
 end

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -2,7 +2,7 @@ module BrowserifyRails
   class Railtie < Rails::Engine
 
     initializer :setup_browserify do |app|
-      app.assets.register_preprocessor 'application/javascript', BrowserifyRails::DirectiveProcessor
+      app.assets.register_postprocessor 'application/javascript', BrowserifyRails::DirectiveProcessor
     end
 
     rake_tasks do

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -5,13 +5,13 @@ class BrowserifyTest < ActionController::IntegrationTest
   test "asset pipeline should serve application.js" do
     get "/assets/application.js"
     assert_response :success
-    assert @response.body == ";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n;"
+    assert @response.body.include? ";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"
   end
 
   test "asset pipeline should serve foo.js" do
     get "/assets/foo.js"
     assert_response :success
-    assert @response.body == ";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n;"
+    assert @response.body.include? ";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"
   end
 
 end


### PR DESCRIPTION
Hi, I made two adjustments:
- Added optional support for coffeescript (using coffeeify)
- Make sure to not wrap plain js files as common js modules, so we can mix-and-match modules with libraries that doesn't implement the module pattern.
