### PR TITLE
Support nested modules (and fix a intermittent test failure)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ test/dummy/public/assets
 test/dummy/public/system
 test/dummy/db/schema.rb
 tmp
-test/dummy/app/assets/javascripts/*.js
+test/dummy/app/assets/javascripts/**/*.js

--- a/lib/browserify-rails/directive_processor.rb
+++ b/lib/browserify-rails/directive_processor.rb
@@ -25,6 +25,7 @@ module BrowserifyRails
 
         deps = JSON.parse(run_command("#{module_deps_cmd} #{pathname}"))
         deps.each do |dep|
+          next if !dep['entry']
           path = File.basename(dep['id'], context.environment.root)
           next if path == File.basename(pathname)
 
@@ -35,6 +36,10 @@ module BrowserifyRails
           end
 
           context.depend_on_asset(path)
+
+          dep['deps'].each do |module_path, asset_path|
+            context.depend_on_asset(asset_path)
+          end
         end
 
         params = "-d"

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -7,24 +7,31 @@ class BrowserifyTest < ActionController::IntegrationTest
 
     FileUtils.cp(File.join(Rails.root, 'app/assets/javascripts/application.js.example'), File.join(Rails.root, 'app/assets/javascripts/application.js'))
     FileUtils.cp(File.join(Rails.root, 'app/assets/javascripts/foo.js.example'), File.join(Rails.root, 'app/assets/javascripts/foo.js'))
+    FileUtils.cp(File.join(Rails.root, 'app/assets/javascripts/nested/index.js.example'), File.join(Rails.root, 'app/assets/javascripts/nested/index.js'))
   end
 
   test "asset pipeline should serve application.js" do
+    expected_output = fixture("application.out.js")
+
     get "/assets/application.js"
     assert_response :success
-    assert @response.body.include?(";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"), 'Output did not match'
+    assert_match expected_output, @response.body
   end
 
   test "asset pipeline should serve foo.js" do
+    expected_output = fixture("foo.out.js")
+
     get "/assets/foo.js"
     assert_response :success
-    assert @response.body.include? ";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"
+    assert_match expected_output, @response.body
   end
 
   test "asset pipeline should regenerate application.js when foo.js changes" do
+    expected_output = fixture("application.out.js")
+
     get "/assets/application.js"
     assert_response :success
-    assert @response.body.include?(";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"), 'Output did not match'
+    assert_match expected_output, @response.body
 
     # Ensure that Sprockets can detect the change to the file modification time
     sleep 1
@@ -32,10 +39,14 @@ class BrowserifyTest < ActionController::IntegrationTest
     File.open(File.join(Rails.root, 'app/assets/javascripts/foo.js'), 'w+') do |f|
       f.puts "module.exports = function (n) { return n * 12 }"
     end
+    expected_output = fixture("foo_changed.out.js")
 
     get "/assets/application.js"
     assert_response :success
-    assert @response.body.include?(";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 12 }\n\n},{}]},{},[1])\n"), 'Output did not match'
+    assert_match expected_output, @response.body
   end
 
+  def fixture(filename)
+    File.open(File.dirname(__FILE__)+"/fixtures/#{filename}").read
+  end
 end

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class BrowserifyTest < ActionController::IntegrationTest
 
   setup do
-    FileUtils.rm_rf(File.join(Rails.root, 'tmp/cache'))
-    FileUtils.mkdir_p(File.join(Rails.root, 'tmp'))
+    Rails.application.assets.cache = nil
+
     FileUtils.cp(File.join(Rails.root, 'app/assets/javascripts/application.js.example'), File.join(Rails.root, 'app/assets/javascripts/application.js'))
     FileUtils.cp(File.join(Rails.root, 'app/assets/javascripts/foo.js.example'), File.join(Rails.root, 'app/assets/javascripts/foo.js'))
   end
@@ -25,6 +25,9 @@ class BrowserifyTest < ActionController::IntegrationTest
     get "/assets/application.js"
     assert_response :success
     assert @response.body.include?(";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"), 'Output did not match'
+
+    # Ensure that Sprockets can detect the change to the file modification time
+    sleep 1
 
     File.open(File.join(Rails.root, 'app/assets/javascripts/foo.js'), 'w+') do |f|
       f.puts "module.exports = function (n) { return n * 12 }"

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -12,7 +12,7 @@ class BrowserifyTest < ActionController::IntegrationTest
   test "asset pipeline should serve application.js" do
     get "/assets/application.js"
     assert_response :success
-    assert @response.body.include? ";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"
+    assert @response.body.include?(";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"), 'Output did not match'
   end
 
   test "asset pipeline should serve foo.js" do
@@ -24,7 +24,7 @@ class BrowserifyTest < ActionController::IntegrationTest
   test "asset pipeline should regenerate application.js when foo.js changes" do
     get "/assets/application.js"
     assert_response :success
-    assert @response.body.include? ";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"
+    assert @response.body.include?(";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 11 }\n\n},{}]},{},[1])\n"), 'Output did not match'
 
     File.open(File.join(Rails.root, 'app/assets/javascripts/foo.js'), 'w+') do |f|
       f.puts "module.exports = function (n) { return n * 12 }"
@@ -32,7 +32,7 @@ class BrowserifyTest < ActionController::IntegrationTest
 
     get "/assets/application.js"
     assert_response :success
-    assert @response.body.include? ";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 12 }\n\n},{}]},{},[1])\n"
+    assert @response.body.include?(";(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require==\"function\"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error(\"Cannot find module '\"+n+\"'\")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require==\"function\"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){\nvar foo = require('./foo');\n\n},{\"./foo\":2}],2:[function(require,module,exports){\nmodule.exports = function (n) { return n * 12 }\n\n},{}]},{},[1])\n"), 'Output did not match'
   end
 
 end

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -39,7 +39,7 @@ class BrowserifyTest < ActionController::IntegrationTest
     File.open(File.join(Rails.root, 'app/assets/javascripts/foo.js'), 'w+') do |f|
       f.puts "module.exports = function (n) { return n * 12 }"
     end
-    expected_output = fixture("foo_changed.out.js")
+    expected_output = fixture("app_foo_changed.out.js")
 
     get "/assets/application.js"
     assert_response :success

--- a/test/dummy/app/assets/javascripts/foo.js.example
+++ b/test/dummy/app/assets/javascripts/foo.js.example
@@ -1,1 +1,2 @@
+require('./nested');
 module.exports = function (n) { return n * 11 }

--- a/test/dummy/app/assets/javascripts/nested/index.js.example
+++ b/test/dummy/app/assets/javascripts/nested/index.js.example
@@ -1,0 +1,1 @@
+module.exports.NESTED = true;

--- a/test/fixtures/app_foo_changed.out.js
+++ b/test/fixtures/app_foo_changed.out.js
@@ -2,6 +2,10 @@
 var foo = require('./foo');
 
 },{"./foo":2}],2:[function(require,module,exports){
-module.exports = function (n) { return n * 12 }
+require('./nested');
+module.exports = function (n) { return n * 11 }
+
+},{"./nested":3}],3:[function(require,module,exports){
+module.exports.NESTED = true;
 
 },{}]},{},[1])

--- a/test/fixtures/application.out.js
+++ b/test/fixtures/application.out.js
@@ -2,6 +2,10 @@
 var foo = require('./foo');
 
 },{"./foo":2}],2:[function(require,module,exports){
+require('./nested');
 module.exports = function (n) { return n * 11 }
+
+},{"./nested":3}],3:[function(require,module,exports){
+module.exports.NESTED = true;
 
 },{}]},{},[1])

--- a/test/fixtures/application.out.js
+++ b/test/fixtures/application.out.js
@@ -1,0 +1,7 @@
+;(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require=="function"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error("Cannot find module '"+n+"'")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require=="function"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){
+var foo = require('./foo');
+
+},{"./foo":2}],2:[function(require,module,exports){
+module.exports = function (n) { return n * 11 }
+
+},{}]},{},[1])

--- a/test/fixtures/foo.out.js
+++ b/test/fixtures/foo.out.js
@@ -1,4 +1,8 @@
 ;(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require=="function"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error("Cannot find module '"+n+"'")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require=="function"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){
+require('./nested');
 module.exports = function (n) { return n * 11 }
+
+},{"./nested":2}],2:[function(require,module,exports){
+module.exports.NESTED = true;
 
 },{}]},{},[1])

--- a/test/fixtures/foo.out.js
+++ b/test/fixtures/foo.out.js
@@ -1,0 +1,4 @@
+;(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require=="function"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error("Cannot find module '"+n+"'")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require=="function"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){
+module.exports = function (n) { return n * 11 }
+
+},{}]},{},[1])

--- a/test/fixtures/foo_changed.out.js
+++ b/test/fixtures/foo_changed.out.js
@@ -1,0 +1,7 @@
+;(function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require=="function"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error("Cannot find module '"+n+"'")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require=="function"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){
+var foo = require('./foo');
+
+},{"./foo":2}],2:[function(require,module,exports){
+module.exports = function (n) { return n * 12 }
+
+},{}]},{},[1])


### PR DESCRIPTION
This adds support for requiring nested modules:

``` javascript
// app.js
require('./foo')

// foo.js
require('./nested')

// nested/index.js
module.exports = TRUE
```

Previously, this would generate an "asset not found" error. I'm a little hazy on what the internals of `#evaluate` are doing with paths, but I think this is a decent enough attempt to solve the problem. At the very least, this provides a failing test case for you to improve upon.

Additionally, I made some improvements to the test code. It makes it easier to make changes to the expected output, slightly improves the failure output, and adds a fix for an intermittent test failure.

The test failure occurs when `foo.js` is modified within the same one second clock cycle as the initial test run. Sprockets can only detect modification times at a one second resolution, so if the file changes within that same one second window, Sprockets cannot tell that the file changes and thus uses its in-memory cached version which then fails the test.
