### PR TITLE
Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ class My::Application < Rails::Application
   # vendor stuff is normally not made for browserification and may stop
   # working.
   config.browserify_rails.paths << /vendor\/assets\/javascripts\/module.js/
+
+  # Environments, in which to generate source maps
+  #
+  # The default is `["development"]`.
+  config.browserify_rails.source_map_environments << "production"
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ Coffeescript is handled seamlessly, if you name your files `*.js.coffee`. That
 way the coffeescript compiler will already have done it's work, when we are
 putting the javascript tools to work.
 
+## Configuration
+
+```ruby
+class My::Application < Rails::Application
+  # Paths, that should be browserified. We browserify everything, that
+  # matches (===) one of the paths. So you will most likely put lambdas
+  # regexes in here.
+  #
+  # By default only files in /app and /node_modules are browserified,
+  # vendor stuff is normally not made for browserification and may stop
+  # working.
+  config.browserify_rails.paths << /vendor\/assets\/javascripts\/module.js/
+end
+```
+
 ## Contributing
 
 Pull requests appreciated.

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -37,7 +37,7 @@ module BrowserifyRails
 
     # @return [<String>] Paths of files, that this file depends on
     def dependencies
-      run_browserify("--list").lines.map(&:strip).select do |path|
+      @dependencies ||= run_browserify("--list").lines.map(&:strip).select do |path|
         # Filter the temp file, where browserify caches the input stream
         File.exists?(path)
       end

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -54,8 +54,7 @@ module BrowserifyRails
     end
 
     def browserify
-      # Only generate source maps in development
-      if Rails.env == "development"
+      if Rails.config.browserify_rails.source_map_environments.include?(Rails.env)
         options = "-d"
       else
         options = ""

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -54,7 +54,7 @@ module BrowserifyRails
     end
 
     def browserify
-      if Rails.config.browserify_rails.source_map_environments.include?(Rails.env)
+      if Rails.application.config.browserify_rails.source_map_environments.include?(Rails.env)
         options = "-d"
       else
         options = ""

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -22,8 +22,12 @@ module BrowserifyRails
 
     private
 
+    # Is this a commonjs module?
+    #
+    # Be here as strict as possible, so that non-commonjs files are not
+    # preprocessed.
     def commonjs_module?
-      data.to_s.include?("module.exports") || data.to_s.include?("require")
+      data.to_s.include?("module.exports") || dependencies.length > 0
     end
 
     # This primarily filters out required files from node modules

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -9,7 +9,7 @@ module BrowserifyRails
     end
 
     def evaluate(context, locals, &block)
-      if commonjs_module?
+      if should_browserify? && commonjs_module?
         asset_dependencies(context.environment.paths).each do |path|
           context.depend_on(path)
         end
@@ -21,6 +21,12 @@ module BrowserifyRails
     end
 
     private
+
+    def should_browserify?
+      Rails.application.config.browserify_rails.paths.any? do |path_spec|
+        path_spec === file
+      end
+    end
 
     # Is this a commonjs module?
     #

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -3,8 +3,8 @@ module BrowserifyRails
     config.browserify_rails = ActiveSupport::OrderedOptions.new
 
     # Which paths should be browserified?
-    config.browserify_rails.paths = [-> (p) { p.start_with?(Rails.root.join("app").to_s) },
-                                     -> (p) { p.start_with?(Rails.root.join("node_modules").to_s) }]
+    config.browserify_rails.paths = [lambda { |p| p.start_with?(Rails.root.join("app").to_s) },
+                                     lambda { |p| p.start_with?(Rails.root.join("node_modules").to_s) }]
 
     # Environments to generate source maps in
     config.browserify_rails.source_map_environments = ["development"]

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -6,6 +6,9 @@ module BrowserifyRails
     config.browserify_rails.paths = [-> (p) { p.start_with?(Rails.root.join("app").to_s) },
                                      -> (p) { p.start_with?(Rails.root.join("node_modules").to_s) }]
 
+    # Environments to generate source maps in
+    config.browserify_rails.source_map_environments = ["development"]
+
     initializer :setup_browserify do |app|
       app.assets.register_postprocessor "application/javascript", BrowserifyRails::BrowserifyProcessor
     end

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -1,5 +1,11 @@
 module BrowserifyRails
   class Railtie < Rails::Engine
+    config.browserify_rails = ActiveSupport::OrderedOptions.new
+
+    # Which paths should be browserified?
+    config.browserify_rails.paths = [-> (p) { p.start_with?(Rails.root.join("app").to_s) },
+                                     -> (p) { p.start_with?(Rails.root.join("node_modules").to_s) }]
+
     initializer :setup_browserify do |app|
       app.assets.register_postprocessor "application/javascript", BrowserifyRails::BrowserifyProcessor
     end


### PR DESCRIPTION
Add configuration options for
- the environments, in which to generate source maps
- which files to browserify. By default only files in `/app` and `/node_modules` are browserified, because browserifying e.g. jquery from the `jquery-rails` gem makes it very hard to use (I could not do it)

Thanks,
Marten
