### PR TITLE
Configuration for command line options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ Coffeescript is handled seamlessly, if you name your files `*.js.coffee`. That
 way the coffeescript compiler will already have done it's work, when we are
 putting the javascript tools to work.
 
+## Browserify command line options
+
+By default `browserify` is run with `-d` option (Enable source maps) in
+development environment and without any options in all other environments.
+
+You can easily extend the options which are used when running `browserify`, by
+adding `config.browserify_rails.commandline_options` to your `config/application.rb`
+or your environment file (`config/environments/*.rb`):
+
+```ruby
+# config/application.rb
+Example::Application.config do
+
+  # Browserify-rails supports options provided as an array:
+  config.browserify_rails.commandline_options = ["-t browserify-shim", "--fast"]
+
+  # or as a string:
+  config.browserify_rails.commandline_options = "-t browserify-shim --fast"
+end
+```
+
 ## Contributing
 
 Pull requests appreciated.
@@ -64,3 +85,4 @@ Pull requests appreciated.
 * [Henry Hsu](https://github.com/hsume2)
 * [Cássio Souza](https://github.com/cassiozen)
 * [Marten Lienen](https://github.com/CQQL)
+* [Lukasz Sagol](https://github.com/zgryw)

--- a/browserify-rails.gemspec
+++ b/browserify-rails.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rails", "~> 3.2"
+  spec.add_development_dependency "mocha"
 end

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -96,15 +96,9 @@ module BrowserifyRails
 
       options.push("-d") if config.source_map_environments.include?(Rails.env)
 
-      if config.commandline_options.present?
-        if config.commandline_options.is_a? Array
-          options.push(*config.commandline_options)
-        else
-          options.push(config.commandline_options)
-        end
-      end
+      options += Array(config.commandline_options) if config.commandline_options.present?
 
-      options.uniq.join(' ')
+      options.uniq.join(" ")
     end
 
     def config

--- a/lib/browserify-rails/browserify_processor.rb
+++ b/lib/browserify-rails/browserify_processor.rb
@@ -44,13 +44,6 @@ module BrowserifyRails
     end
 
     def browserify
-      # Only generate source maps in development
-      if Rails.env == "development"
-        options = "-d"
-      else
-        options = ""
-      end
-
       run_browserify(options)
     end
 
@@ -86,6 +79,26 @@ module BrowserifyRails
       end
 
       stdout
+    end
+
+    def options
+      options = []
+
+      options.push("-d") if Rails.env.development?
+
+      if config.commandline_options.present?
+        if config.commandline_options.is_a? Array
+          options.push(*config.commandline_options)
+        else
+          options.push(config.commandline_options)
+        end
+      end
+
+      options.uniq.join(' ')
+    end
+
+    def config
+      BrowserifyRails::Railtie.config.browserify_rails
     end
   end
 end

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -1,5 +1,7 @@
 module BrowserifyRails
   class Railtie < Rails::Engine
+    config.browserify_rails = ActiveSupport::OrderedOptions.new
+
     initializer :setup_browserify do |app|
       app.assets.register_postprocessor "application/javascript", BrowserifyRails::BrowserifyProcessor
     end

--- a/test/browserify_processor_test.rb
+++ b/test/browserify_processor_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class BrowserifyProcessorTest < ActiveSupport::TestCase
+  setup do
+    @empty_module = fixture("empty_module.js")
+  end
+
+  test "should run command without options if none provided" do
+    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
+
+    assert_equal "", processor.send(:options)
+  end
+
+  test "should run command without options if empty array provided" do
+    engine_config.commandline_options = []
+    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
+
+    assert_equal "", processor.send(:options)
+  end
+
+  test "should convert options provided as an array to string" do
+    engine_config.commandline_options = ["-d", "-i test1.js"]
+
+    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
+    assert_equal "-d -i test1.js", processor.send(:options)
+  end
+
+  test "should allow providing options as a string" do
+    engine_config.commandline_options = "-d -i test2.js"
+    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
+
+    assert_equal "-d -i test2.js", processor.send(:options)
+  end
+
+  test "should remove duplicate options when provided as an array" do
+    engine_config.commandline_options = ["-d", "-i test3.js", "-d"]
+
+    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
+    assert_equal "-d -i test3.js", processor.send(:options)
+  end
+
+  test "should add -d option if in development environment" do
+    engine_config.commandline_options = ["-i test4.js"]
+    Rails.env.stubs(:development?).returns(true)
+
+    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
+    assert_equal "-d -i test4.js", processor.send(:options)
+  end
+
+  def engine_config
+    BrowserifyRails::Railtie.config.browserify_rails
+  end
+end

--- a/test/browserify_processor_test.rb
+++ b/test/browserify_processor_test.rb
@@ -33,9 +33,9 @@ class BrowserifyProcessorTest < ActiveSupport::TestCase
     assert_equal "-d -i test3.js", @processor.send(:options)
   end
 
-  test "should add -d option if in development environment" do
+  test "should add -d option if current env is in source_maps_env list" do
     stub_engine_config :commandline_options, ["-i test4.js"]
-    Rails.env.stubs(:development?).returns(true)
+    stub_engine_config :source_map_environments, [Rails.env]
 
     assert_equal "-d -i test4.js", @processor.send(:options)
   end

--- a/test/browserify_processor_test.rb
+++ b/test/browserify_processor_test.rb
@@ -3,51 +3,44 @@ require 'test_helper'
 class BrowserifyProcessorTest < ActiveSupport::TestCase
   setup do
     @empty_module = fixture("empty_module.js")
+    @processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
   end
 
   test "should run command without options if none provided" do
-    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
-
-    assert_equal "", processor.send(:options)
+    stub_engine_config :commandline_options, nil
+    assert_equal "", @processor.send(:options)
   end
 
   test "should run command without options if empty array provided" do
-    engine_config.commandline_options = []
-    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
-
-    assert_equal "", processor.send(:options)
+    stub_engine_config :commandline_options, []
+    assert_equal "", @processor.send(:options)
   end
 
   test "should convert options provided as an array to string" do
-    engine_config.commandline_options = ["-d", "-i test1.js"]
-
-    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
-    assert_equal "-d -i test1.js", processor.send(:options)
+    stub_engine_config :commandline_options, ["-d", "-i test1.js"]
+    assert_equal "-d -i test1.js", @processor.send(:options)
   end
 
   test "should allow providing options as a string" do
-    engine_config.commandline_options = "-d -i test2.js"
-    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
+    stub_engine_config :commandline_options, "-d -i test2.js"
 
-    assert_equal "-d -i test2.js", processor.send(:options)
+    assert_equal "-d -i test2.js", @processor.send(:options)
   end
 
   test "should remove duplicate options when provided as an array" do
-    engine_config.commandline_options = ["-d", "-i test3.js", "-d"]
+    stub_engine_config :commandline_options, ["-d", "-i test3.js", "-d"]
 
-    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
-    assert_equal "-d -i test3.js", processor.send(:options)
+    assert_equal "-d -i test3.js", @processor.send(:options)
   end
 
   test "should add -d option if in development environment" do
-    engine_config.commandline_options = ["-i test4.js"]
+    stub_engine_config :commandline_options, ["-i test4.js"]
     Rails.env.stubs(:development?).returns(true)
 
-    processor = BrowserifyRails::BrowserifyProcessor.new { |p| @empty_module }
-    assert_equal "-d -i test4.js", processor.send(:options)
+    assert_equal "-d -i test4.js", @processor.send(:options)
   end
 
-  def engine_config
-    BrowserifyRails::Railtie.config.browserify_rails
+  def stub_engine_config(key, value)
+    @processor.send(:config).stubs(key).returns(value)
   end
 end

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -79,8 +79,4 @@ class BrowserifyTest < ActionController::IntegrationTest
     get "/assets/application.js"
     assert_match /BrowserifyRails::BrowserifyError/, @response.body
   end
-
-  def fixture(filename)
-    File.open(File.join(File.dirname(__FILE__), "/fixtures/#{filename}")).read.strip
-  end
 end

--- a/test/fixtures/empty_module.js
+++ b/test/fixtures/empty_module.js
@@ -1,0 +1,2 @@
+// minimal js fixture that passes common_js_module? test
+module.exports = {}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,3 +12,9 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 # Remove tmp dir of dummy app
 FileUtils.rm_rf "#{File.dirname(__FILE__)}/dummy/tmp"
+
+ActiveSupport::TestCase.class_eval do
+  def fixture(filename)
+    File.open(File.join(File.dirname(__FILE__), "/fixtures/#{filename}")).read.strip
+  end
+end


### PR DESCRIPTION
Option to configure command line options used when running `browserify` command. Really useful for people who are using transforms when bundling with browserify, but can be handy in many other situations.

Tests included.
