### PR TITLE
More granular configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tmp
 test/dummy/app/assets/javascripts/*.js
 test/dummy/app/assets/javascripts/**/*.js
 test/dummy/app/assets/javascripts/**/*.js.coffee
+/.ruby-*

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -12,6 +12,11 @@ module BrowserifyRails
     # Load granular configuration
     filename = File.join(Dir.pwd, 'config', 'browserify.yml')
     configuration = YAML::load(File.read(filename)) if File.exist? filename
+
+    # TODO we don't have Rails.root yet so either figure out how to get that or if there is a cleaner way to do this
+    filename_under_test = File.join(Dir.pwd, 'test', 'dummy', 'config', 'browserify.yml')
+    configuration = YAML::load(File.read(filename_under_test)) if File.exist? filename_under_test
+
     config.browserify_rails_granular = configuration || {}
 
     initializer :setup_browserify do |app|

--- a/lib/browserify-rails/railtie.rb
+++ b/lib/browserify-rails/railtie.rb
@@ -9,6 +9,11 @@ module BrowserifyRails
     # Environments to generate source maps in
     config.browserify_rails.source_map_environments = ["development"]
 
+    # Load granular configuration
+    filename = File.join(Dir.pwd, 'config', 'browserify.yml')
+    configuration = YAML::load(File.read(filename)) if File.exist? filename
+    config.browserify_rails_granular = configuration || {}
+
     initializer :setup_browserify do |app|
       app.assets.register_postprocessor "application/javascript", BrowserifyRails::BrowserifyProcessor
     end

--- a/lib/browserify-rails/version.rb
+++ b/lib/browserify-rails/version.rb
@@ -1,3 +1,3 @@
 module BrowserifyRails
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/test/dummy/config/browserify.yml
+++ b/test/dummy/config/browserify.yml
@@ -1,0 +1,8 @@
+debug: false
+javascript:
+  app_main:
+    require:
+      - app_a_huge_library
+  app_secondary:
+    external:
+      - app_a_huge_library


### PR DESCRIPTION
I need to add some tests for this which I'll work on later this evening but what do you think of this? You can try it out by using the more-granular-configuration branch of my fork of browserify-rails-sample:

https://github.com/cymen/browserify-rails-sample/tree/more-granular-configuration

If you access /beep, the page loads robot.js and beep.js (you can also access /boop). The two browserified-file contents are:

robot.js:

```
require=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"9WgEjc":[function(require,module,exports){
module.exports = function (s) { return s.toUpperCase() + '!' };

},{}],"./robot.js":[function(require,module,exports){
module.exports=require('9WgEjc');
},{}]},{},[])
// omitting rest of file (source map)
```

beep.js:

```
(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
var $ = require('jquery-browserify'),
    robot = require('./robot.js'),
    says = 'beep';

console.log(robot(says));

$('document').ready(function() {
  $('#root').html(robot(says));
});

},{"./robot.js":"9WgEjc","jquery-browserify":2}],2:[function(require,module,exports){
// omitting rest of file (jquery-browserify and source map)
```

And the configuration is actually simpler than I thought:

```
robot:
  require:
    - ./robot.js
beep:
  external:
    - robot.js
boop:
  external:
    - robot.js
```

I need to try it with a slightly more complex example however it works great when moving from /beep to /boop (robot.js is same so cached, etc).

Fixes #16 
